### PR TITLE
fix: vulnerability scan w/trivy

### DIFF
--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           persist-credentials: false
       -
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: stable
+          check-latest: true
+          cache: true
+      -
         name: Vulnerability scan by trivy
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
@@ -39,6 +45,7 @@ jobs:
           hide-progress: false
           output: trivy-code-report.sarif
           scanners: vuln,secret
+          trivy-version: v0.68.0
           exit-code: 0
       -
         name: Upload trivy findings to code scanning dashboard


### PR DESCRIPTION
We should setup the latest go before loading trivy, otherwise an older go version installed on the runner is checked.

Also: specified a more up to date trivy version than the default used by the action.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
