### PR TITLE
fix: add a delay before the contributors workflow sets auto-merge

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -81,6 +81,36 @@ jobs:
         name: Auto-approve PR
         run: gh pr review --approve "$PR_URL"
       -
-        # TODO: should wait for all workflows to complete before merging
+        name: Wait for all workflow runs to complete
+        run: |
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          echo "Waiting for all checks to complete on PR #${PR_NUMBER}..."
+
+          MAX_WAIT=600  # 10 minutes max wait
+          ELAPSED=0
+          SLEEP_INTERVAL=10
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            # Get all workflow runs for this PR's head SHA
+            PR_DATA=$(gh pr view "$PR_NUMBER" --json headRefOid,statusCheckRollup)
+            HEAD_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
+
+            # Check if any workflows are still in progress
+            IN_PROGRESS=$(echo "$PR_DATA" | jq -r '.statusCheckRollup[] | select(.status == "IN_PROGRESS" or .status == "QUEUED" or .status == "PENDING") | .name' | wc -l)
+
+            if [ "$IN_PROGRESS" -eq 0 ]; then
+              echo "::notice::All workflow runs completed for SHA ${HEAD_SHA}"
+              break
+            fi
+
+            echo "Still waiting for $IN_PROGRESS check(s) to complete..."
+            sleep $SLEEP_INTERVAL
+            ELAPSED=$((ELAPSED + SLEEP_INTERVAL))
+          done
+
+          if [ $ELAPSED -ge $MAX_WAIT ]; then
+            echo "::warning::Timeout waiting for all checks to complete, proceeding anyway"
+          fi
+      -
         name: Auto-merge PR
         run: gh pr merge --auto --rebase "$PR_URL"


### PR DESCRIPTION
Problem: when auto-merge is set, the PR merges as soon as the required check status is okay, meaning that the next job that uploads test coverage always fails (branch is deleted). This is not blocking but kind of untidy.

Solution: introduced a loop that waits for all PR jobs to complete before auto-merge is enabled.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
