### PR TITLE
feat(release): added support for remote shared config to be used to c…

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -42,6 +42,16 @@ on:
           (use "|" to replace end of line).
         required: false
         type: string
+      cliff-config:
+        type: string
+        required: false
+        default: '.cliff.toml'
+        description: 'Path to the git-cliff config file in the caller repository'
+      cliff-config-url:
+        type: string
+        required: false
+        default: 'https://raw.githubusercontent.com/go-openapi/ci-workflows/refs/heads/master/.cliff.toml'
+        description: 'URL to the remote git-cliff config file (used if local config does not exist)'
 
 jobs:
   tag-release:
@@ -130,4 +140,6 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.tag-release.outputs.next-tag}}
+      cliff-config: ${{ inputs.cliff-config }}
+      cliff-config-url: ${{ inputs.cliff-config-url }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,16 @@ on:
       tag:
         type: string
         required: true
+      cliff-config:
+        type: string
+        required: false
+        default: '.cliff.toml'
+        description: 'Path to the git-cliff config file in the caller repository'
+      cliff-config-url:
+        type: string
+        required: false
+        default: 'https://raw.githubusercontent.com/go-openapi/ci-workflows/refs/heads/master/.cliff.toml'
+        description: 'URL to the remote git-cliff config file (used if local config does not exist)'
 
 jobs:
   gh-release:
@@ -49,22 +59,49 @@ jobs:
           echo "Message in git tag ${{ inputs.tag }}"
           echo "$MESSAGE"
       -
-        name: Generate release notes
+        name: Check for local cliff config
+        id: check-config
+        run: |
+          if [ -f "${{ inputs.cliff-config }}" ]; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+            echo "::notice title=release::Local config file '${{ inputs.cliff-config }}' found"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice title=release::Local config file '${{ inputs.cliff-config }}' not found, will use remote config"
+          fi
+      -
+        name: Generate release notes (local config)
         # this uses git-cliff to generate a release note from the commit history
-        id: notes
+        if: ${{ steps.check-config.outputs.exists == 'true' }}
+        id: notes-local
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPO: ${{ github.repository }}
         uses: orhun/git-cliff-action@d77b37db2e3f7398432d34b72a12aa3e2ba87e51 # v4.6.0
         with:
-          config: '.cliff.toml'
+          config: ${{ inputs.cliff-config }}
           args: >-
+            --current
+            --with-tag-message '${{ steps.get-message.outputs.message }}'
+      -
+        name: Generate release notes (remote config)
+        # this uses git-cliff action with remote config URL
+        if: ${{ steps.check-config.outputs.exists == 'false' }}
+        id: notes-remote
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPO: ${{ github.repository }}
+        uses: orhun/git-cliff-action@d77b37db2e3f7398432d34b72a12aa3e2ba87e51 # v4.6.0
+        with:
+          config: ''
+          args: >-
+            --config-url '${{ inputs.cliff-config-url }}'
             --current
             --with-tag-message '${{ steps.get-message.outputs.message }}'
       -
         name: Create github release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          body: ${{ steps.notes.outputs.content }}
+          body: ${{ steps.check-config.outputs.exists == 'true' && steps.notes-local.outputs.content || steps.notes-remote.outputs.content }}
           tag_name: ${{ inputs.tag }}
           generate_release_notes: false # skip auto-generated release notes from github API

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -14,6 +14,16 @@ on:
       tag:
         type: string
         required: true
+      cliff-config:
+        type: string
+        required: false
+        default: '.cliff.toml'
+        description: 'Path to the git-cliff config file in the caller repository'
+      cliff-config-url:
+        type: string
+        required: false
+        default: 'https://raw.githubusercontent.com/go-openapi/ci-workflows/refs/heads/master/.cliff.toml'
+        description: 'URL to the remote git-cliff config file (used if local config does not exist)'
 
 jobs:
   gh-release:
@@ -26,4 +36,6 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ github.ref_name }}
+      cliff-config: ${{ inputs.cliff-config }}
+      cliff-config-url: ${{ inputs.cliff-config-url }}
     secrets: inherit


### PR DESCRIPTION
…onfigure git-cliff

This change affects the release.yml workflow by bringing in new options.

Existing behavior is not modified, thanks to default input values (.cliff.toml).

New feature:
If no local .cliff.toml config is found (or any specific local config file provided as input), a remote config is used.

The default is to use as a shared config the .cliff.toml of this repo on master.

* fixes #36

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
