### PR TITLE
feat: add workflow to monitor stalled bot PRs

### DIFF
--- a/.github/workflows/local-monitor-bot-pr.yml
+++ b/.github/workflows/local-monitor-bot-pr.yml
@@ -1,0 +1,20 @@
+name: Monitor bot PRs [Test only]
+
+# description: |
+# This workflow mimics how a go-openapi repo would typically invoke the common workflow.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '18 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  monitor-pr:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/monitor-bot-pr.yml
+    secrets: inherit

--- a/.github/workflows/monitor-bot-pr.yml
+++ b/.github/workflows/monitor-bot-pr.yml
@@ -1,0 +1,148 @@
+name: Monitor bot PRs
+
+on:
+  workflow_call:
+    inputs:
+      enable-organization-bot:
+        description: |
+          Enable detection and rebase of stalled PRs initiated by the organization bot.
+
+        type: string
+        required: false
+        default: "true"
+      organization-bot:
+        description: |
+          The bot user that opens pull requests on behalf of the organization,
+          whose stalled PRs should be rebased automatically.
+
+          Example: bot-go-openapi[bot]
+
+        type: string
+        required: false
+        default: "bot-go-openapi[bot]"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  dependabot-prs:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      -
+        name: Request a rebase on stalled dependabot PRs
+        # A stalled PR is one that should have auto-merged but did not, because
+        # its branch fell behind the base ref. We detect it when all of:
+        #   * the PR is open and authored by the dependabot bot,
+        #   * auto-merge is enabled (autoMergeRequest is not null) -- this
+        #     excludes dependency groups that are deliberately not auto-merged,
+        #   * it has not been updated for at least one day,
+        #   * its merge state is BEHIND (head ref needs to catch up to base),
+        #   * no CI check has failed.
+        # GitHub never rebases dependabot branches by itself, so we comment
+        # "@dependabot rebase". Dependabot rebases the branch, CI restarts and
+        # auto-merge is evaluated again.
+        run: |
+          cutoff="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+          echo "::notice title=monitor::Looking for stalled dependabot PRs not updated since ${cutoff}"
+
+          mapfile -t urls < <(
+            gh pr list --repo "${REPO}" \
+              --state open --limit 10 \
+              --author 'dependabot[bot]' \
+              --json url,author,autoMergeRequest,mergeStateStatus,updatedAt,statusCheckRollup \
+            | jq -r --arg cutoff "${cutoff}" '
+                .[]
+                | select(.author.is_bot)
+                | select(.autoMergeRequest != null)
+                | select(.updatedAt <= $cutoff)
+                | select(.mergeStateStatus == "BEHIND")
+                | select(
+                    [.statusCheckRollup[]? | (.conclusion // .state // "")]
+                    | map(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE")
+                    | any
+                    | not
+                  )
+                | .url
+              '
+          )
+
+          if [ "${#urls[@]}" -eq 0 ]; then
+            echo "::notice title=monitor::No stalled dependabot PRs found"
+            exit 0
+          fi
+
+          for pr_url in "${urls[@]}"; do
+            echo "::notice title=rebase::Requesting dependabot rebase for ${pr_url}"
+            gh pr comment "${pr_url}" --body "@dependabot rebase"
+          done
+
+  organization-bot-prs:
+    if: ${{ inputs.enable-organization-bot == 'true' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      ORG_BOT: ${{ inputs.organization-bot }}
+    steps:
+      -
+        name: Rebase the branch of stalled organization bot PRs
+        # Same detection as for dependabot PRs. The organization bot does not
+        # answer rebase comments, so we ask GitHub to update the branch directly
+        # with "gh pr update-branch --rebase". This requires the PR branch to live
+        # in this repository (not a fork). The rebase restarts CI and auto-merge
+        # is evaluated again.
+        run: |
+          cutoff="$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)"
+          echo "::notice title=monitor::Looking for stalled ${ORG_BOT} PRs not updated since ${cutoff}"
+
+          mapfile -t urls < <(
+            gh pr list --repo "${REPO}" \
+              --state open --limit 10 \
+              --author "${ORG_BOT}" \
+              --json url,author,autoMergeRequest,mergeStateStatus,updatedAt,statusCheckRollup \
+            | jq -r --arg cutoff "${cutoff}" '
+                .[]
+                | select(.author.is_bot)
+                | select(.autoMergeRequest != null)
+                | select(.updatedAt <= $cutoff)
+                | select(.mergeStateStatus == "BEHIND")
+                | select(
+                    [.statusCheckRollup[]? | (.conclusion // .state // "")]
+                    | map(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE")
+                    | any
+                    | not
+                  )
+                | .url
+              '
+          )
+
+          if [ "${#urls[@]}" -eq 0 ]; then
+            echo "::notice title=monitor::No stalled ${ORG_BOT} PRs found"
+            exit 0
+          fi
+
+          for pr_url in "${urls[@]}"; do
+            echo "::notice title=rebase::Rebasing branch for ${pr_url}"
+            set +e
+            output="$(gh pr update-branch --rebase "${pr_url}" 2>&1)"
+            code=$?
+            set -e
+            if [ "${code}" -ne 0 ]; then
+              echo "::warning title=rebase::Could not rebase ${pr_url}: ${output}"
+              continue
+            fi
+            echo "${output}"
+          done


### PR DESCRIPTION
When a repository evolves quickly, bot-authored PRs with auto-merge enabled can fall behind the base branch and never merge. monitor-bot-pr.yml is a reusable workflow that, on a schedule, finds such stalled PRs (open, auto-merge enabled, BEHIND base, idle for at least one day, no failed CI) and unblocks them:

  * dependabot PRs are commented "@dependabot rebase", so dependabot rebases the branch and CI restarts;
  * organization bot PRs are rebased directly via "gh pr update-branch --rebase", which restarts CI.

PRs for dependency groups that are not configured for auto-merge are excluded by the autoMergeRequest != null filter.

local-monitor-bot-pr.yml exercises the shared workflow daily, mirroring how consuming go-openapi repositories will invoke it.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
