### PR TITLE
fix(coverage): skip cleanly when PR head branch was deleted by auto-merge

### DIFF
--- a/.github/workflows/collect-coverage.yml
+++ b/.github/workflows/collect-coverage.yml
@@ -16,17 +16,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Check whether PR head branch still exists
+        id: head
+        # Auto-merge does not wait on this job (codecov uploads are flaky, so
+        # the status is intentionally not required). If the PR auto-merges
+        # before this job runs, GitHub's auto-delete-branch policy removes
+        # the source branch and the checkout step below fails with a noisy
+        # "Reference not found" error. Detect that case here and skip the
+        # rest of the job cleanly so the workflow conclusion stays green.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ -z "${PR_HEAD_REPO}" || -z "${PR_HEAD_REF}" ]]; then
+            # Not a pull_request context (e.g. workflow called from push) -- proceed.
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if gh api "repos/${PR_HEAD_REPO}/branches/${PR_HEAD_REF}" --silent >/dev/null 2>&1; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::notice title=skip-coverage::PR head ${PR_HEAD_REPO}@${PR_HEAD_REF} no longer exists (likely auto-merged before coverage upload); skipping"
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+          fi
+      -
+        if: ${{ steps.head.outputs.available == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       -
+        if: ${{ steps.head.outputs.available == 'true' }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
           check-latest: true
           cache: true
       -
+        if: ${{ steps.head.outputs.available == 'true' }}
         name: Download coverage artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -35,6 +63,7 @@ jobs:
           # artifacts resolve as folders
           path: coverage/
       -
+        if: ${{ steps.head.outputs.available == 'true' }}
         name: Reprocess coverage paths
         # on projects with a v2 suffix, the go import path reported by coverage doesn't match
         # well the actual path. codecov knows about that for the root module, but is unable
@@ -48,6 +77,7 @@ jobs:
             sed -i "s|${name}|${target}|" $(find coverage -type f -name \*.coverage.\*.out)
           done
       -
+        if: ${{ steps.head.outputs.available == 'true' }}
         name: Upload coverage to codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:


### PR DESCRIPTION

The collect-coverage job is intentionally not a required check (codecov uploads are flaky), so auto-merge can fire before it runs. When that happens, GitHub's auto-delete-branch policy removes the PR head and the checkout step fails with a noisy "Reference not found" error, leaving a red status on an otherwise successful merge.

Add a precheck step that queries the GitHub API for the head branch. If it's gone, emit a notice and gate the remaining steps off, so the job conclusion stays green. Normal PRs (branch still exists) are unaffected -- coverage is still uploaded and real failures still surface.

collect-reports.yml does not need the same fix: it has no checkout step (downloads artifacts by run_id, uses head.sha as a literal value).

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
